### PR TITLE
laguardia airport name changed, no spaces in most recent api responses

### DIFF
--- a/ch_03/2-using_the_weather_api.ipynb
+++ b/ch_03/2-using_the_weather_api.ipynb
@@ -787,7 +787,7 @@
        " 'mindate': '1939-10-07',\n",
        " 'maxdate': '2019-05-02',\n",
        " 'latitude': 40.7792,\n",
-       " 'name': 'LA GUARDIA AIRPORT, NY US',\n",
+       " 'name': 'LAGUARDIA AIRPORT, NY US',\n",
        " 'datacoverage': 1,\n",
        " 'id': 'GHCND:USW00014732',\n",
        " 'elevationUnit': 'METERS',\n",
@@ -801,7 +801,7 @@
    ],
    "source": [
     "laguardia = get_item(\n",
-    "    'La Guardia', {'locationid' : nyc['id']}, 'stations'\n",
+    "    'LaGuardia', {'locationid' : nyc['id']}, 'stations'\n",
     ")\n",
     "laguardia"
    ]


### PR DESCRIPTION
The airport name has changed, no data comes back for "La Guardia" anymore, only "LaGuardia" (no space).